### PR TITLE
Created library.properties to enable library to be used in Arduino IDE

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=Ds1302
+version=1.0.4
+author=Rafa Couto <caligari@treboada.net>
+maintainer=Rafa Couto <caligari@treboada.net>
+sentence=A C/C++ library to use DS1302 RTC chip.
+paragraph=A C/C++ library to use DS1302 RTC chip.
+category=Device Control
+url=https://github.com/Treboada/Ds1302
+architectures=avr,esp8266,esp32


### PR DESCRIPTION
With this `library.properties` at the toplevel of a package your library is usable in the Arduino IDE and `arduino-cli`.