### PR TITLE
Fix bitmask for reading year register in getDateTime()

### DIFF
--- a/src/Ds1302.cpp
+++ b/src/Ds1302.cpp
@@ -62,7 +62,7 @@ void Ds1302::getDateTime(DateTime* dt)
     dt->day    = _bcd2dec(_readByte() & 0b00111111);
     dt->month  = _bcd2dec(_readByte() & 0b00011111);
     dt->dow    = _bcd2dec(_readByte() & 0b00000111);
-    dt->year   = _bcd2dec(_readByte() & 0b01111111);
+    dt->year   = _bcd2dec(_readByte() & 0b11111111);
     _end();
 }
 


### PR DESCRIPTION
Hello, and thanks for the awesome library!
I found a mistake in the bitmask used to read the year register in Ds1302::getDateTime(), which causes wrong readings when the year is greater than 80. This PR fixes it - I've already tested the change.
Cheers!